### PR TITLE
调用read_body()之后才能读取body的内容

### DIFF
--- a/openresty/get_req_body.md
+++ b/openresty/get_req_body.md
@@ -13,6 +13,7 @@ http {
 
         location /test {
             content_by_lua_block {
+                ngx.req.read_body()
                 local data = ngx.req.get_body_data()
                 ngx.say("hello ", data)
             }


### PR DESCRIPTION
实践中发现一个小问题